### PR TITLE
 Cambio en renderizado de mathjax

### DIFF
--- a/eolpersistenttab/static/html/eolpersistenttab.html
+++ b/eolpersistenttab/static/html/eolpersistenttab.html
@@ -1,4 +1,4 @@
-<div class="eolpersistenttab_block {{xblock.theme}}">
+<div class="eolpersistenttab_block {{xblock.theme}}" id="{{ xblock.location }}">
     <div class="btn-fixed animated fadeInRight">
         <a id="btn_{{location}}" class="persistent-btn">
             <span>

--- a/eolpersistenttab/static/js/src/eolpersistenttab.js
+++ b/eolpersistenttab/static/js/src/eolpersistenttab.js
@@ -31,7 +31,21 @@ function EolPersistentTabXBlock(runtime, element, settings) {
             }
         }
         
-        MathJax.Hub.Queue(["Typeset", MathJax.Hub]);// Renderiza MathJax nuevamente
+        var persitentid = "persistenttab_" + settings.location;
+        renderMathForSpecificElements(persitentid);
     });
+
+    function renderMathForSpecificElements(id) {
+        if (typeof MathJax !== "undefined") {
+            var $persistent = $('#' + id);
+            if ($persistent.length) {
+                $persistent.find('.text').each(function (index, persistelem) {
+                    MathJax.Hub.Queue(["Typeset", MathJax.Hub, persistelem]);
+                });
+            }
+        } else {
+            console.warn("MathJax no está cargado.");
+        }
+    }
 }
 


### PR DESCRIPTION
Ahora se compila latex tanto dentro del titlu del botón, como en el contenido del modal persistente

revisor @tomaspemora 